### PR TITLE
Remove `native text` converter

### DIFF
--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -1753,7 +1753,7 @@ class SSH:  # pylint: disable=too-few-public-methods
                 alg_db = alg_pair.db
                 for alg_type, alg_list in alg_pair.items():
                     for alg_name in alg_list:
-                        alg_name_native = utils.to_ntext(alg_name)
+                        alg_name_native = utils.to_utext(alg_name)
                         alg_desc = alg_db[alg_type].get(alg_name_native)
                         if alg_desc is None:
                             continue
@@ -2686,7 +2686,7 @@ def output_algorithm(alg_db, alg_type, alg_name, unknown_algs, alg_max_len=0, al
     texts = []
     if len(alg_name.strip()) == 0:
         return
-    alg_name_native = utils.to_ntext(alg_name)
+    alg_name_native = utils.to_utext(alg_name)
     if alg_name_native in alg_db[alg_type]:
         alg_desc = alg_db[alg_type][alg_name_native]
         ldesc = len(alg_desc)
@@ -3020,15 +3020,6 @@ class Utils:
         raise cls._type_err(v, 'unicode text')
 
     @classmethod
-    def to_ntext(cls, v, enc='utf-8'):
-        # type: (Union[str, bytes], str) -> str
-        if isinstance(v, str):
-            return v
-        elif isinstance(v, bytes):
-            return v.decode(enc)
-        raise cls._type_err(v, 'native text')
-
-    @classmethod
     def _is_ascii(cls, v, char_filter=lambda x: x <= 127):
         # type: (str, Callable[[int], bool]) -> bool
         r = False
@@ -3053,7 +3044,7 @@ class Utils:
                     if errors == 'ignore':
                         continue
                     r.append(63)
-            return cls.to_ntext(r.decode('ascii'))
+            return cls.to_utext(r.decode('ascii'))
         raise cls._type_err(v, 'ascii')
 
     @classmethod

--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -1051,7 +1051,7 @@ class SSH1:
             ciphers = []
             for i in range(len(SSH1.CIPHERS)):
                 if self.__supported_ciphers_mask & (1 << i) != 0:
-                    ciphers.append(utils.to_utext(SSH1.CIPHERS[i]))
+                    ciphers.append(utils.to_text(SSH1.CIPHERS[i]))
             return ciphers
 
         @property
@@ -1065,7 +1065,7 @@ class SSH1:
             auths = []
             for i in range(1, len(SSH1.AUTHS)):
                 if self.__supported_authentications_mask & (1 << i) != 0:
-                    auths.append(utils.to_utext(SSH1.AUTHS[i]))
+                    auths.append(utils.to_text(SSH1.AUTHS[i]))
             return auths
 
         def write(self, wbuf):
@@ -1753,7 +1753,7 @@ class SSH:  # pylint: disable=too-few-public-methods
                 alg_db = alg_pair.db
                 for alg_type, alg_list in alg_pair.items():
                     for alg_name in alg_list:
-                        alg_name_native = utils.to_utext(alg_name)
+                        alg_name_native = utils.to_text(alg_name)
                         alg_desc = alg_db[alg_type].get(alg_name_native)
                         if alg_desc is None:
                             continue
@@ -2686,7 +2686,7 @@ def output_algorithm(alg_db, alg_type, alg_name, unknown_algs, alg_max_len=0, al
     texts = []
     if len(alg_name.strip()) == 0:
         return
-    alg_name_native = utils.to_utext(alg_name)
+    alg_name_native = utils.to_text(alg_name)
     if alg_name_native in alg_db[alg_type]:
         alg_desc = alg_db[alg_type][alg_name_native]
         ldesc = len(alg_desc)
@@ -3011,7 +3011,7 @@ class Utils:
         raise cls._type_err(v, 'bytes')
 
     @classmethod
-    def to_utext(cls, v, enc='utf-8'):
+    def to_text(cls, v, enc='utf-8'):
         # type: (Union[str, bytes], str) -> str
         if isinstance(v, str):
             return v
@@ -3044,7 +3044,7 @@ class Utils:
                     if errors == 'ignore':
                         continue
                     r.append(63)
-            return cls.to_utext(r.decode('ascii'))
+            return cls.to_text(r.decode('ascii'))
         raise cls._type_err(v, 'ascii')
 
     @classmethod

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,12 +14,12 @@ class TestUtils:
         with pytest.raises(TypeError):
             self.utils.to_bytes(123)
 
-    def test_to_utext(self):
-        assert self.utils.to_utext(b'fran\xc3\xa7ais') == 'fran\xe7ais'
-        assert self.utils.to_utext('fran\xe7ais') == 'fran\xe7ais'
+    def test_to_text(self):
+        assert self.utils.to_text(b'fran\xc3\xa7ais') == 'fran\xe7ais'
+        assert self.utils.to_text('fran\xe7ais') == 'fran\xe7ais'
         # other
         with pytest.raises(TypeError):
-            self.utils.to_utext(123)
+            self.utils.to_text(123)
 
     def test_is_ascii(self):
         assert self.utils.is_ascii('francais') is True

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,13 +21,6 @@ class TestUtils:
         with pytest.raises(TypeError):
             self.utils.to_utext(123)
 
-    def test_to_ntext(self):
-        assert self.utils.to_ntext('fran\xc3\xa7ais') == 'fran\xc3\xa7ais'
-        assert self.utils.to_ntext(b'fran\xc3\xa7ais') == 'fran\xe7ais'
-        # other
-        with pytest.raises(TypeError):
-            self.utils.to_ntext(123)
-
     def test_is_ascii(self):
         assert self.utils.is_ascii('francais') is True
         assert self.utils.is_ascii('fran\xe7ais') is False


### PR DESCRIPTION
This was only necessary with Python 2. After Python 2 removal, both
functions `to_ntext` and `to_utext` exactly did the same.

Also, rename `to_utext` to `to_text` as in Python 3 there is only text (and bytes).