### PR TITLE
Simplify `mypy` config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,8 @@ deps =
 	mypy
 commands =
 	-mypy \
+	    --strict \
 		--show-error-context \
-		--config-file {toxinidir}/tox.ini \
 		--html-report {env:MYPYHTML}.py3.{envname} \
 		{posargs:{env:SSHAUDIT}}
 
@@ -85,24 +85,6 @@ commands =
 		l = [x for x in o.split(b'\n') if x and b'Unused import' not in x]; \
 		print(b'\n'.join(l).decode('utf-8')); \
 		sys.exit(1 if len(l) > 0 else 0)"
-
-
-[mypy]
-ignore_missing_imports = False
-follow_imports = normal
-disallow_incomplete_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-disallow_untyped_defs = True
-check_untyped_defs = True
-disallow_subclassing_any = True
-warn_redundant_casts = True
-warn_return_any = True
-warn_unreachable = True
-warn_unused_ignores = True
-strict_optional = True
-strict_equality = True
-strict = True
 
 [pylint]
 reports = no


### PR DESCRIPTION
Instead of specifying stricter checks one by one, just run `mypy` in
`strict` mode.

modified:   tox.ini