### PR TITLE
Fixed --json option under Python 3.8

### DIFF
--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -3242,7 +3242,7 @@ def build_struct(banner, kex=None, pkm=None, client_host=None):
 		host_keys = kex.host_keys()
 
 		# Normalize all RSA key types to 'ssh-rsa'.  Otherwise, due to Python's order-indifference dictionary types, we would iterate key types in unpredictable orders, which interferes with the docker testing framework (i.e.: tests would fail because elements are reported out of order, even though the output is semantically the same).
-		for host_key_type in host_keys.keys():
+		for host_key_type in list(host_keys.keys()):
 			if host_key_type in SSH2.HostKeyTest.RSA_FAMILY:
 				val = host_keys[host_key_type]
 				del(host_keys[host_key_type])


### PR DESCRIPTION
Modifying a dictionary whilst modifying it is undefined behaviour. Until
Python 3.8 this was not flagged by the runtime. Python 3.8 and onward
raise a RuntimeError instead.

```
± python3.8 ssh-audit.py -j raspberrypi2.local
{"banner": {"comments": "Debian-10+deb10u2", "protocol": [2, 0], "raw":
"SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u2", "software": "OpenSSH_7.9p1"},
"compression": ["none", "zlib@openssh.com"], "enc":
["chacha20-poly1305@openssh.com", "aes128-ctr", "aes192-ctr",
"aes256-ctr", "aes128-gcm@openssh.com", "aes256-gcm@openssh.com"],
"fingerprints": [{"fp":
"SHA256:bMjkjAz1qji2r36sLs1kW480yIgh6+/CWtXiuId2BmQ", "type":
"ssh-ed25519"}, {"fp":
"SHA256:nWqnLAaLWRPxH+QMBdC+C7Bi5u3zWSuR8foSea/Iwqc", "type":
"ssh-rsa"}], "kex": [{"algorithm": "curve25519-sha256"}, {"algorithm":
"curve25519-sha256@libssh.org"}, {"algorithm": "ecdh-sha2-nistp256"},
{"algorithm": "ecdh-sha2-nistp384"}, {"algorithm":
"ecdh-sha2-nistp521"}, {"algorithm":
"diffie-hellman-group-exchange-sha256", "keysize": 2048}, {"algorithm":
"diffie-hellman-group16-sha512"}, {"algorithm":
"diffie-hellman-group18-sha512"}, {"algorithm":
"diffie-hellman-group14-sha256"}, {"algorithm":
"diffie-hellman-group14-sha1"}], "key": [{"algorithm": "rsa-sha2-512",
"keysize": 4096}, {"algorithm": "rsa-sha2-256", "keysize": 4096},
{"algorithm": "ssh-rsa", "keysize": 4096}, {"algorithm": "rsa-sha2-512",
"keysize": 4096}, {"algorithm": "rsa-sha2-256", "keysize": 4096},
{"algorithm": "ssh-rsa", "keysize": 4096}, {"algorithm":
"ecdsa-sha2-nistp256"}, {"algorithm": "ssh-ed25519"}], "mac":
["umac-64-etm@openssh.com", "umac-128-etm@openssh.com",
"hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com",
"hmac-sha1-etm@openssh.com", "umac-64@openssh.com",
"umac-128@openssh.com", "hmac-sha2-256", "hmac-sha2-512", "hmac-sha1"]}
```

fixes #49