### PR TITLE
Remove unused variables

### DIFF
--- a/ssh-audit.py
+++ b/ssh-audit.py
@@ -1306,9 +1306,7 @@ class SSH2:  # pylint: disable=too-few-public-methods
                         if err is not None:
                             return
 
-                        unused = None  # pylint: disable=unused-variable
-                        unused2 = None  # pylint: disable=unused-variable
-                        unused, unused2, err = s.get_banner()
+                        _, _, err = s.get_banner()
                         if err is not None:
                             s.close()
                             return


### PR DESCRIPTION
When you get multiple values from unpacking, and you do not need all of
them, there is the convention to assign `_` to the unused ones.

This fixes #42 

modified:   ssh-audit.py