### PR TITLE
Colour no longer disabled on older vers of Windows. If ssh-audit invoked with a manual parameter and the colorama library was not imported then colour output is disabled.

### DIFF
--- a/src/ssh_audit/ssh_audit.py
+++ b/src/ssh_audit/ssh_audit.py
@@ -1024,13 +1024,7 @@ def main() -> int:
 
     # If we're on Windows, but the colorama module could not be imported, print a warning if we're in verbose mode.
     if (sys.platform == 'win32') and ('colorama' not in sys.modules):
-        out.v("WARNING: colorama module not found.  Colorized output will be ddisabled.", write_now=True)
-
-    # Disable color output on Windiows 8 and Windows Server 2012, as they are still supported by Microsoft (until Jan. 2023 and Oct. 2023, respectively); they do not support ANSI color codes.  According to https://docs.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version, the major versions of Server 2016, Server 2019, and Windows 10 are all 10.
-    if (sys.platform == 'win32') and (sys.getwindowsversion().major < 10):  # pylint: disable=no-member
-        aconf.colors = False
-        out.use_colors = False
-        out.v("Disabling color output on this platform since it is not supported (Windows major version: %d)." % sys.getwindowsversion().major)  # pylint: disable=no-member
+        out.v("WARNING: colorama module not found.  Colorized output will be disabled.", write_now=True)
 
     # If we're outputting JSON, turn off colors and ensure 'info' level messages go through.
     if aconf.json:
@@ -1038,6 +1032,10 @@ def main() -> int:
         out.use_colors = False
 
     if aconf.manual:
+        # If the colorama module was not be imported, turn off colors in order
+        # to output a plain text version of the man page.
+        if (sys.platform == 'win32') and ('colorama' not in sys.modules):
+            out.use_colors = False
         retval = windows_manual(out)
         out.write()
         sys.exit(retval)

--- a/ssh-audit.1
+++ b/ssh-audit.1
@@ -1,4 +1,4 @@
-.TH SSH-AUDIT 1 "October 19, 2020"
+.TH SSH-AUDIT 1 "February 7, 2021"
 .SH NAME
 \fBssh-audit\fP \- SSH server & client configuration auditor
 .SH SYNOPSIS


### PR DESCRIPTION
Colour no longer disabled on older vers of Windows. If ssh-audit invoked with a manual parameter and the colorama library was not imported then colour output is disabled.