### PR TITLE
Usage now includes '-g' and '--gex-test' parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ usage: ssh-audit.py [options] <host>
                                software config (use -p to change port;
                                use -t to change timeout)
    -d,  --debug            Enable debug output.
+   -g,  --gex-test=<x[,y,...] | min:pref:max[,min:pref:max,...] | x-y[:step]>  dh gex modulus size test
    -j,  --json             JSON output (use -jj to enable indents)
    -l,  --level=<level>    minimum output level (info|warn|fail)
    -L,  --list-policies    list all the official, built-in policies


### PR DESCRIPTION
Updated the Usage section of `README.md` to include `-g` and `--gex-test` parameters.