### PR TITLE
Add install instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ $ docker pull positronsecurity/ssh-audit
 ```
 (Then run with: `docker run -it -p 2222:2222 positronsecurity/ssh-audit 10.1.1.1`)
 
+To install on Arch Linux:
+```
+$ sudo pacman -S ssh-audit
+```
+
 ## Web Front-End
 For convenience, a web front-end on top of the command-line tool is available at [https://www.ssh-audit.com/](https://www.ssh-audit.com/).
 


### PR DESCRIPTION
I've verified that the version installed on Arch is indeed coming from the jtesta fork:
```
    [root@2e9f9f9f8cdf /]# grep PRETTY /etc/os-release
    PRETTY_NAME="Arch Linux"
    [root@2e9f9f9f8cdf /]# ssh-audit --version | head -n 1
    # ssh-audit v2.5.0, https://github.com/jtesta/ssh-audit
```

I've verified that it works on Garuda Linux too (and probably other Arch derivatives as well).