### PR TITLE
Docker: Build multi-arch container images for amd64, arm64 and arm/v7

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -4,10 +4,17 @@ ifeq ($(VERSION),)
 endif
 
 all:
-	docker build -t positronsecurity/ssh-audit:${VERSION} .
-	docker tag positronsecurity/ssh-audit:${VERSION} positronsecurity/ssh-audit:latest
+	docker buildx build \
+		--platform linux/amd64,linux/arm64,linux/arm/v7 \
+		--tag positronsecurity/ssh-audit:${VERSION} \
+		--tag positronsecurity/ssh-audit:latest \
+		.
 
 upload:
 	docker login
-	docker push positronsecurity/ssh-audit:${VERSION}
-	docker push positronsecurity/ssh-audit:latest
+	docker buildx build \
+		--platform linux/amd64,linux/arm64,linux/arm/v7 \
+		--tag positronsecurity/ssh-audit:${VERSION} \
+		--tag positronsecurity/ssh-audit:latest \
+		--push \
+		.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -10,6 +10,9 @@ all:
 		--tag positronsecurity/ssh-audit:latest \
 		.
 
+local-build:
+	docker build -t positronsecurity/ssh-audit:${VERSION} .
+
 upload:
 	docker login
 	docker buildx build \


### PR DESCRIPTION
Hey there! 👋 

I really like ssh-audit and using Docker for use it to keep my machines "clean". I was getting a warning on my Apple Silicon based Mac and also couldn't run it on my Raspberry Pi (no real reason, was just curious if it would work):

```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

This warning made me realised there is no native `arm64` image available. That's an easy fix, esp. for a Python based image.

My assumption is, that you're using `Makefile.docker` to build and release `ssh-audit`'s container images. I changed the existing build targets to use `docker buildx` to build for `amd64`, `arm64` and `arm/v7` platforms. Not sure if more architectures work, I have no means to test anything but those currently.

I also added a `local-test` build target, which uses `docker build`. This makes it easier to test, without having to push into a Docker container registry (multi-arch images are a little tricky with Docker still).

Long story short: `make -f Makefile.docker upload` will build images for the three mentioned architectures and pushes them to Docker Hub. They all have the same tag and docker clients will automatically pick the correct one for the platform/architecture they are requesting.

I did test everything locally with a local docker registry and it works nicely now everywhere.

~~

PS: You can read about how to deal with multi-arch images in a comment from @CRogers [over here](https://github.com/docker/buildx/issues/59#issuecomment-1168619521) which helped me figure out how to actually test this.