### PR TITLE
Add cleanup for apt cache files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim
 WORKDIR /
 
 # Update the image to remediate any vulnerabilities.
-RUN apt clean && apt update && apt -y dist-upgrade && apt clean
+RUN apt clean && apt update && apt -y dist-upgrade && apt clean rm -rf /var/lib/apt/lists/*
 
 # Remove suid & sgid bits from all files.
 RUN find / -xdev -perm /6000 -exec chmod ug-s {} \; 2> /dev/null || true


### PR DESCRIPTION
Adding this step decreases the size of the image.

ssh-audit-new                                           latest                 0c391ba567ee   39 minutes ago   **157MB**
ssh-audit-old                                           latest                 a425e0043125   40 minutes ago   **176MB**