### PR TITLE
Properly upgrade packages and clean up apt cache in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim
 WORKDIR /
 
 # Update the image to remediate any vulnerabilities.
-RUN apt clean && apt update && apt -y dist-upgrade && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt -y upgrade && apt -y dist-upgrade && rm -rf /var/lib/apt/lists/*
 
 # Remove suid & sgid bits from all files.
 RUN find / -xdev -perm /6000 -exec chmod ug-s {} \; 2> /dev/null || true


### PR DESCRIPTION
Add `apt upgrade` before `apt dist-upgrade`, and replace `apt clean` with `rm -rf /var/lib/apt/lists/*`, result:

```
REPOSITORY     TAG       IMAGE ID       CREATED              SIZE
ssh-audit      after     03e247aee0cc   About a minute ago   131MB
ssh-audit      before    609962ceafb1   About a minute ago   150MB
```