### PR TITLE
use python alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
-FROM python:3-slim
+# syntax=docker/dockerfile:latest
+FROM scratch AS files
 
-WORKDIR /
+# Copy ssh-audit code to temporary container
+COPY ssh-audit.py /
+COPY src/ /
+
+FROM python:3-alpine AS runtime
 
 # Update the image to remediate any vulnerabilities.
-RUN apt update && apt -y upgrade && apt -y dist-upgrade && rm -rf /var/lib/apt/lists/*
+RUN apk upgrade -U --no-cache -a -l && \ 
+    # Remove suid & sgid bits from all files.
+    find / -xdev -perm /6000 -exec chmod ug-s {} \; 2> /dev/null || true
 
-# Remove suid & sgid bits from all files.
-RUN find / -xdev -perm /6000 -exec chmod ug-s {} \; 2> /dev/null || true
-
-# Copy the ssh-audit code.
-COPY ssh-audit.py .
-COPY src/ .
+# Copy the ssh-audit code from files container.
+COPY --from=files / /
 
 # Allow listening on 2222/tcp for client auditing.
 EXPOSE 2222


### PR DESCRIPTION
not as exotic as the previous pr ;)

changes the base image to the official python alpine image
moves the initial file copies to a separate container
reduced the run statements

```
REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
ssh-audit                          after     eb69438e2b93   4 seconds ago    83.7MB
ssh-audit                          before    b3251df186d9   23 seconds ago   196MB
```

also cves are drastically reduced :)