### PR TITLE
Recognize LANcom LCOS software and support ed448 key extraction

### DIFF
--- a/src/ssh_audit/hostkeytest.py
+++ b/src/ssh_audit/hostkeytest.py
@@ -157,6 +157,7 @@ class HostKeyTest:
                 ca_key_type = kex_group.get_ca_type()
                 ca_modulus_size = kex_group.get_ca_size()
                 out.d("Hostkey type: [%s]; hostkey size: %u; CA type: [%s]; CA modulus size: %u" % (host_key_type, hostkey_modulus_size, ca_key_type, ca_modulus_size), write_now=True)
+                out.d("Raw hostkey bytes (%d): [%s]" % (len(raw_hostkey_bytes), raw_hostkey_bytes.hex()), write_now=True)
 
                 # Record all the host key info.
                 server_kex.set_host_key(host_key_type, raw_hostkey_bytes, hostkey_modulus_size, ca_key_type, ca_modulus_size)

--- a/src/ssh_audit/hostkeytest.py
+++ b/src/ssh_audit/hostkeytest.py
@@ -52,6 +52,9 @@ class HostKeyTest:
 
         'ssh-ed25519':                      {'cert': False, 'variable_key_len': False},
         'ssh-ed25519-cert-v01@openssh.com': {'cert': True, 'variable_key_len': False},
+
+        'ssh-ed448':                      {'cert': False, 'variable_key_len': False},
+        # 'ssh-ed448-cert-v01@openssh.com': {'cert': True,  'variable_key_len': False},
     }
 
     TWO2K_MODULUS_WARNING = '2048-bit modulus only provides 112-bits of symmetric strength'

--- a/src/ssh_audit/kexdh.py
+++ b/src/ssh_audit/kexdh.py
@@ -134,6 +134,9 @@ class KexDH:  # pragma: nocover
         if self.__hostkey_type == 'ssh-ed25519':
             self.out.d("%s has a fixed host key modulus of 32." % self.__hostkey_type)
             self.__hostkey_n_len = 32
+        elif self.__hostkey_type == 'ssh-ed448':
+            self.out.d("%s has a fixed host key modulus of 57." % self.__hostkey_type)
+            self.__hostkey_n_len = 57
         else:
             # Here is the modulus size & actual modulus of the host key public key.
             hostkey_n, self.__hostkey_n_len, ptr = KexDH.__get_bytes(hostkey, ptr)

--- a/src/ssh_audit/software.py
+++ b/src/ssh_audit/software.py
@@ -224,4 +224,8 @@ class Software:
         mx = re.match(r'^PuTTY_Release_(.*)', software)
         if mx:
             return cls(None, Product.PuTTY, mx.group(1), None, None)
+        mx = re.match(r'^lancom(.*)', software)
+        if mx:
+            v, p = 'LANcom', 'LCOS sshd'
+            return cls(v, p, mx.group(1), None, None)
         return None


### PR DESCRIPTION
_(Re-creation of https://github.com/arthepsy/ssh-audit/pull/51 after realizing that project is defunct and this one has advanced much further 😄)_

LANcom router devices appear to be primarily used in Germany (see [1]
for examples on the public Internet), and they appear to support the
`ssh-ed448` key type which is documented in [2], but which has never
been supported by any as-yet-released version of OpenSSH.

[1] https://www.shodan.io/search?query=ssh+%22ed448%22
[2] https://datatracker.ietf.org/doc/html/rfc8709#name-public-key-format