### PR TITLE
fix for issue https://github.com/jtesta/ssh-audit/issues/284

### DIFF
--- a/src/ssh_audit/ssh_audit.py
+++ b/src/ssh_audit/ssh_audit.py
@@ -1441,7 +1441,7 @@ def target_worker_thread(host: str, port: int, shared_aconf: AuditConf) -> Tuple
 
     out = OutputBuffer()
     out.verbose = shared_aconf.verbose
-    my_aconf = copy.deepcopy(shared_aconf)
+    my_aconf = copy.copy(shared_aconf)
     my_aconf.host = host
     my_aconf.port = port
 


### PR DESCRIPTION
I propose this change to fix the handling of multiple files during policy and regular audit scans.

I am unsure why `deepcopy` was used here. If it is 100% nessearcy the Auditconf class needs be updated i guess ?