### PR TITLE
Enable HostKeyTest to extract ECDSA and DSA keys

### DIFF
--- a/src/ssh_audit/hostkeytest.py
+++ b/src/ssh_audit/hostkeytest.py
@@ -55,6 +55,17 @@ class HostKeyTest:
 
         'ssh-ed448':                      {'cert': False, 'variable_key_len': False},
         # 'ssh-ed448-cert-v01@openssh.com': {'cert': True,  'variable_key_len': False},
+
+        'ecdsa-sha2-nistp256': {'cert': False, 'variable_key_len': False},
+        'ecdsa-sha2-nistp384': {'cert': False, 'variable_key_len': False},
+        'ecdsa-sha2-nistp521': {'cert': False, 'variable_key_len': False},
+
+        'ecdsa-sha2-nistp256-cert-v01@openssh.com': {'cert': True, 'variable_key_len': False},
+        'ecdsa-sha2-nistp384-cert-v01@openssh.com': {'cert': True, 'variable_key_len': False},
+        'ecdsa-sha2-nistp521-cert-v01@openssh.com': {'cert': True, 'variable_key_len': False},
+
+        'ssh-dss':                      {'cert': False, 'variable_key_len': True},
+        'ssh-dss-cert-v01@openssh.com': {'cert': True,  'variable_key_len': True},
     }
 
     TWO2K_MODULUS_WARNING = '2048-bit modulus only provides 112-bits of symmetric strength'


### PR DESCRIPTION
Their certificate-embedded counterparts are enabled as well.

As with RSA, it *is* possible for DSA keys to be of variable length (not just 1024 bits), so I've added `{'variable_key_len': True}` to the relevant `HOST_KEY_TYPES` entries, although this key-value pair is otherwise unused.