### PR TITLE
Switch `connect_ex` result checks to use `errno` lookups

### DIFF
--- a/src/ssh_audit/dheat.py
+++ b/src/ssh_audit/dheat.py
@@ -21,6 +21,7 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
 """
+import errno
 import multiprocessing
 import os
 import queue
@@ -442,7 +443,7 @@ class DHEat:
                 # out.d("Creating socket (%u of %u already exist)..." % (len(socket_dict), concurrent_sockets), write_now=True)
                 ret = s.connect_ex((target_ip_address, aconf.port))
                 num_attempted_connections += 1
-                if ret in [0, 115]:  # Check if connection is successful or EINPROGRESS.
+                if ret in [0, errno.EINPROGRESS]:  # Check if connection is successful or EINPROGRESS.
                     socket_dict[s] = now
                 else:
                     out.d("connect_ex() returned: %d" % ret, write_now=True)

--- a/src/ssh_audit/dheat.py
+++ b/src/ssh_audit/dheat.py
@@ -443,10 +443,10 @@ class DHEat:
                 # out.d("Creating socket (%u of %u already exist)..." % (len(socket_dict), concurrent_sockets), write_now=True)
                 ret = s.connect_ex((target_ip_address, aconf.port))
                 num_attempted_connections += 1
-                if ret in [0, errno.EINPROGRESS]:  # Check if connection is successful or EINPROGRESS.
+                if ret in [0, errno.EINPROGRESS]:
                     socket_dict[s] = now
                 else:
-                    out.d("connect_ex() returned: %d" % ret, write_now=True)
+                    out.d("connect_ex() returned: %s (%d)" % (os.strerror(ret), ret), write_now=True)
 
             # out.d("Calling select() on %u sockets..." % len(socket_dict), write_now=True)
             socket_list: List[socket.socket] = [*socket_dict]  # Get a list of sockets from the dictionary.


### PR DESCRIPTION
Closes #288 by performing the `errno` lookups dynamically based on the host platform.