### PR TITLE
security: replace random.randint with secrets.randbelow in DHeat key exchange

### DIFF
--- a/src/ssh_audit/dheat.py
+++ b/src/ssh_audit/dheat.py
@@ -26,6 +26,7 @@ import multiprocessing
 import os
 import queue
 import random
+import secrets
 import select
 import socket
 import struct
@@ -599,7 +600,7 @@ class DHEat:
         elif chosen_alg == "ecdh-sha2-nistp521":
             e = DHEat.HARDCODED_NISTP521
         else:
-            e = b"\x00" + int.to_bytes(random.randint(0, max_msb), length=1, byteorder="big") + os.urandom(self.e_rand_len)
+            e = b"\x00" + int.to_bytes(secrets.randbelow(max_msb + 1), length=1, byteorder="big") + os.urandom(self.e_rand_len)
 
         payload = message_code + struct.pack("!L", len(e)) + e
         pad_len, padding = self.get_padding(payload)


### PR DESCRIPTION
Bandit B311 — standard PRNG used in security-sensitive context.

`random.randint(0, max_msb)` in `DHeat._make_dh_kex_init_payload()` generates
the leading byte of the synthetic DH exponent `e`. While this value is used for
DoS simulation rather than key derivation, using a CSPRNG is the correct choice
for a security tool.

**Change:**
- Added `import secrets`
- Replaced `random.randint(0, max_msb)` with `secrets.randbelow(max_msb + 1)`
  (avoids modulo bias present in the `os.urandom(1) % n` pattern)

No logic change — same range, same usage.

Detected and patched by [RepoMend](https://callmedai.com).